### PR TITLE
DT-13 Afero S3 FS support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/huandu/go-sqlbuilder v1.4.2
 	github.com/pkg/errors v0.8.1
 	github.com/sirupsen/logrus v1.4.2
+	github.com/spf13/afero v1.1.2
 	github.com/spf13/viper v1.4.0
 	github.com/streadway/amqp v0.0.0-20190815230801-eade30b20f1d
 	github.com/urfave/cli v1.22.4

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -48,6 +48,10 @@ func ES() *elasticsearch.ES {
 	return current().ES
 }
 
+func FS() *afero.Fs {
+	return current().FS
+}
+
 func current() *Env {
 	if e == nil {
 		e = New()

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"github.com/betterme-dev/go-server-core/pkg/elasticsearch"
 	"github.com/betterme-dev/go-server-core/pkg/mq"
+	"github.com/spf13/afero"
 )
 
 var e *Env
@@ -12,6 +13,7 @@ type Env struct {
 	Db       *sql.DB
 	MqClient *mq.Client
 	ES       *elasticsearch.ES
+	FS       *afero.Fs
 }
 
 func New() *Env {
@@ -28,6 +30,9 @@ func SetQueue(q *mq.Client) {
 
 func SetElasticSearch(es *elasticsearch.ES) {
 	current().ES = es
+}
+func SetFS(fs *afero.Fs) {
+	current().FS = fs
 }
 
 func DB() *sql.DB {

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -31,6 +31,7 @@ func SetQueue(q *mq.Client) {
 func SetElasticSearch(es *elasticsearch.ES) {
 	current().ES = es
 }
+
 func SetFS(fs *afero.Fs) {
 	current().FS = fs
 }

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -12,8 +12,8 @@ var e *Env
 type Env struct {
 	Db       *sql.DB
 	MqClient *mq.Client
-	ES       *elasticsearch.ES
-	FS       *afero.Fs
+	Es       *elasticsearch.ES
+	Fs       *afero.Fs
 }
 
 func New() *Env {
@@ -29,11 +29,11 @@ func SetQueue(q *mq.Client) {
 }
 
 func SetElasticSearch(es *elasticsearch.ES) {
-	current().ES = es
+	current().Es = es
 }
 
 func SetFS(fs *afero.Fs) {
-	current().FS = fs
+	current().Fs = fs
 }
 
 func DB() *sql.DB {
@@ -45,11 +45,11 @@ func Queue() *mq.Client {
 }
 
 func ES() *elasticsearch.ES {
-	return current().ES
+	return current().Es
 }
 
 func FS() *afero.Fs {
-	return current().FS
+	return current().Fs
 }
 
 func current() *Env {

--- a/pkg/filesystem/s3/error.go
+++ b/pkg/filesystem/s3/error.go
@@ -1,0 +1,22 @@
+package s3
+
+type (
+	Error struct {
+		Message string
+	}
+
+	NotImplementedError struct {
+		Error
+	}
+
+	FileClosedError struct {
+		Error
+	}
+	UndefinedWhenceError struct {
+		Error
+	}
+)
+
+func (e Error) Error() string {
+	return e.Message
+}

--- a/pkg/filesystem/s3/s3_file.go
+++ b/pkg/filesystem/s3/s3_file.go
@@ -1,0 +1,269 @@
+package s3
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3iface"
+	"github.com/spf13/afero"
+)
+
+// File represents a file in S3.
+// It is not thread safe.
+type File struct {
+	bucket string
+	name   string
+	s3Fs   afero.Fs
+	s3API  s3iface.S3API
+
+	// state
+	offset int
+	closed bool
+
+	// readdir state
+	readdirContinuationToken *string
+	readdirNotTruncated      bool
+}
+
+var _ afero.File = (*File)(nil)
+
+// NewFile initializes an File object.
+func NewFile(bucket, name string, s3API s3iface.S3API, s3Fs afero.Fs) *File {
+	return &File{
+		bucket: bucket,
+		name:   name,
+		s3API:  s3API,
+		s3Fs:   s3Fs,
+		offset: 0,
+		closed: false,
+	}
+}
+
+// Name returns the filename, i.e. S3 path without the bucket name.
+func (f *File) Name() string { return f.name }
+
+// Readdir reads the contents of the directory associated with file and
+// returns a slice of up to n FileInfo values, as would be returned
+// by ListObjects, in directory order. Subsequent calls on the same file will yield further FileInfos.
+//
+// If n > 0, Readdir returns at most n FileInfo structures. In this case, if
+// Readdir returns an empty slice, it will return a non-nil error
+// explaining why. At the end of a directory, the error is io.EOF.
+//
+// If n <= 0, Readdir returns all the FileInfo from the directory in
+// a single slice. In this case, if Readdir succeeds (reads all
+// the way to the end of the directory), it returns the slice and a
+// nil error. If it encounters an error before the end of the
+// directory, Readdir returns the FileInfo read until that point
+// and a non-nil error.
+func (f *File) Readdir(n int) ([]os.FileInfo, error) {
+	if f.readdirNotTruncated {
+		return nil, io.EOF
+	}
+	if n <= 0 {
+		return f.ReaddirAll()
+	}
+	// ListObjects treats leading slashes as part of the directory name
+	// It also needs a trailing slash to list contents of a directory.
+	name := trimLeadingSlash(f.Name()) + "/"
+	output, err := f.s3API.ListObjectsV2(&s3.ListObjectsV2Input{
+		ContinuationToken: f.readdirContinuationToken,
+		Bucket:            aws.String(f.bucket),
+		Prefix:            aws.String(name),
+		Delimiter:         aws.String("/"),
+		MaxKeys:           aws.Int64(int64(n)),
+	})
+	if err != nil {
+		return nil, err
+	}
+	f.readdirContinuationToken = output.NextContinuationToken
+	if !(*output.IsTruncated) {
+		f.readdirNotTruncated = true
+	}
+	var fis []os.FileInfo
+	for _, subfolder := range output.CommonPrefixes {
+		fis = append(fis, NewFileInfo(filepath.Base("/"+*subfolder.Prefix), true, 0, time.Time{}))
+	}
+	for _, fileObject := range output.Contents {
+		if hasTrailingSlash(*fileObject.Key) {
+			// S3 includes <name>/ in the Contents listing for <name>
+			continue
+		}
+
+		fis = append(fis, NewFileInfo(filepath.Base("/"+*fileObject.Key), false, *fileObject.Size, *fileObject.LastModified))
+	}
+
+	return fis, nil
+}
+
+func (f *File) ReaddirAll() ([]os.FileInfo, error) {
+	var fileInfos []os.FileInfo
+	for {
+		infos, err := f.Readdir(100)
+		fileInfos = append(fileInfos, infos...)
+		if err != nil {
+			if err == io.EOF {
+				break
+			} else {
+				return nil, err
+			}
+		}
+	}
+	return fileInfos, nil
+}
+
+// Readdirnames reads and returns a slice of names from the directory f.
+//
+// If n > 0, Readdirnames returns at most n names. In this case, if
+// Readdirnames returns an empty slice, it will return a non-nil error
+// explaining why. At the end of a directory, the error is io.EOF.
+//
+// If n <= 0, Readdirnames returns all the names from the directory in
+// a single slice. In this case, if Readdirnames succeeds (reads all
+// the way to the end of the directory), it returns the slice and a
+// nil error. If it encounters an error before the end of the
+// directory, Readdirnames returns the names read until that point and
+// a non-nil error.
+func (f *File) Readdirnames(n int) ([]string, error) {
+	fi, err := f.Readdir(n)
+	names := make([]string, len(fi))
+	for i, f := range fi {
+		_, names[i] = filepath.Split(f.Name())
+	}
+	return names, err
+}
+
+// Stat returns the FileInfo structure describing file.
+// If there is an error, it will be of type *PathError.
+func (f *File) Stat() (os.FileInfo, error) {
+	return f.s3Fs.Stat(f.Name())
+}
+
+// Sync is a noop.
+func (f *File) Sync() error {
+	return nil
+}
+
+// Truncate changes the size of the file.
+// It does not change the I/O offset.
+// If there is an error, it will be of type *PathError.
+func (f *File) Truncate(_ int64) error {
+	panic("implement Truncate")
+	return nil
+}
+
+// WriteString is like Write, but writes the contents of string s rather than
+// a slice of bytes.
+func (f *File) WriteString(s string) (int, error) {
+	return f.Write([]byte(s))
+}
+
+// Close closes the File, rendering it unusable for I/O.
+// It returns an error, if any.
+func (f *File) Close() error {
+	f.closed = true
+	return nil
+}
+
+// Read reads up to len(b) bytes from the File.
+// It returns the number of bytes read and an error, if any.
+// EOF is signaled by a zero count with err set to io.EOF.
+func (f *File) Read(p []byte) (int, error) {
+	if f.closed {
+		// mimic os.File's read after close behavior
+		panic("read after close")
+	}
+	if f.offset != 0 {
+		panic("TODO: non-offset == 0 read")
+	}
+	if len(p) == 0 {
+		return 0, nil
+	}
+	output, err := f.s3API.GetObject(&s3.GetObjectInput{
+		Bucket: aws.String(f.bucket),
+		Key:    aws.String(f.name),
+	})
+	if err != nil {
+		return 0, err
+	}
+	defer func() {
+		_ = output.Body.Close()
+	}()
+
+	n, err := output.Body.Read(p)
+	f.offset += n
+	return n, err
+}
+
+// ReadAt reads len(p) bytes from the file starting at byte offset off.
+// It returns the number of bytes read and the error, if any.
+// ReadAt always returns a non-nil error when n < len(b).
+// At end of file, that error is io.EOF.
+func (f *File) ReadAt(p []byte, off int64) (n int, err error) {
+	_, err = f.Seek(off, 0)
+	if err != nil {
+		return
+	}
+	n, err = f.Read(p)
+	return
+}
+
+// Seek sets the offset for the next Read or Write on file to offset, interpreted
+// according to whence: 0 means relative to the origin of the file, 1 means
+// relative to the current offset, and 2 means relative to the end.
+// It returns the new offset and an error, if any.
+// The behavior of Seek on a file opened with O_APPEND is not specified.
+func (f *File) Seek(offset int64, whence int) (int64, error) {
+	switch whence {
+	case 0:
+		f.offset = int(offset)
+	case 1:
+		f.offset += int(offset)
+	case 2:
+		// can probably do this if we had GetObjectOutput (ContentLength)
+		panic("TODO: whence == 2 seek")
+	}
+	return int64(f.offset), nil
+}
+
+// Write writes len(b) bytes to the File.
+// It returns the number of bytes written and an error, if any.
+// Write returns a non-nil error when n != len(b).
+func (f *File) Write(p []byte) (int, error) {
+	if f.closed {
+		// mimic os.File's write after close behavior
+		panic("write after close")
+	}
+	if f.offset != 0 {
+		panic("TODO: non-offset == 0 write")
+	}
+	readSeeker := bytes.NewReader(p)
+	size := int(readSeeker.Size())
+	if _, err := f.s3API.PutObject(&s3.PutObjectInput{
+		Bucket:               aws.String(f.bucket),
+		Key:                  aws.String(f.name),
+		Body:                 readSeeker,
+		ServerSideEncryption: aws.String("AES256"),
+	}); err != nil {
+		return 0, err
+	}
+	f.offset += size
+	return size, nil
+}
+
+// WriteAt writes len(p) bytes to the file starting at byte offset off.
+// It returns the number of bytes written and an error, if any.
+// WriteAt returns a non-nil error when n != len(p).
+func (f *File) WriteAt(p []byte, off int64) (n int, err error) {
+	_, err = f.Seek(off, 0)
+	if err != nil {
+		return
+	}
+	n, err = f.Write(p)
+	return
+}

--- a/pkg/filesystem/s3/s3_file.go
+++ b/pkg/filesystem/s3/s3_file.go
@@ -153,8 +153,7 @@ func (f *File) Sync() error {
 // It does not change the I/O offset.
 // If there is an error, it will be of type *PathError.
 func (f *File) Truncate(_ int64) error {
-	panic("implement Truncate")
-	return nil
+	return NotImplementedError{Error{Message: "implement truncated"}}
 }
 
 // WriteString is like Write, but writes the contents of string s rather than
@@ -176,7 +175,7 @@ func (f *File) Close() error {
 func (f *File) Read(p []byte) (int, error) {
 	if f.closed {
 		// mimic os.File's read after close behavior
-		panic("read after close")
+		return 0, FileClosedError{Error{Message: "read after close"}}
 	}
 
 	if len(p) == 0 {
@@ -224,8 +223,9 @@ func (f *File) Seek(offset int64, whence int) (int64, error) {
 		f.offset += int(offset)
 	case 2:
 		// can probably do this if we had GetObjectOutput (ContentLength)
-		panic("TODO: whence == 2 seek")
+		return 0, UndefinedWhenceError{Error{Message: "TODO: whence == 2 seek"}}
 	}
+
 	return int64(f.offset), nil
 }
 
@@ -235,7 +235,7 @@ func (f *File) Seek(offset int64, whence int) (int64, error) {
 func (f *File) Write(p []byte) (int, error) {
 	if f.closed {
 		// mimic os.File's write after close behavior
-		panic("write after close")
+		return 0, FileClosedError{Error{Message: "write after close"}}
 	}
 	readSeeker := bytes.NewReader(p)
 	size := int(readSeeker.Size())

--- a/pkg/filesystem/s3/s3_file.go
+++ b/pkg/filesystem/s3/s3_file.go
@@ -178,9 +178,7 @@ func (f *File) Read(p []byte) (int, error) {
 		// mimic os.File's read after close behavior
 		panic("read after close")
 	}
-	if f.offset != 0 {
-		panic("TODO: non-offset == 0 read")
-	}
+
 	if len(p) == 0 {
 		return 0, nil
 	}
@@ -196,7 +194,7 @@ func (f *File) Read(p []byte) (int, error) {
 	}()
 
 	n, err := output.Body.Read(p)
-	f.offset += n
+
 	return n, err
 }
 
@@ -239,9 +237,6 @@ func (f *File) Write(p []byte) (int, error) {
 		// mimic os.File's write after close behavior
 		panic("write after close")
 	}
-	if f.offset != 0 {
-		panic("TODO: non-offset == 0 write")
-	}
 	readSeeker := bytes.NewReader(p)
 	size := int(readSeeker.Size())
 	if _, err := f.s3API.PutObject(&s3.PutObjectInput{
@@ -252,7 +247,7 @@ func (f *File) Write(p []byte) (int, error) {
 	}); err != nil {
 		return 0, err
 	}
-	f.offset += size
+
 	return size, nil
 }
 

--- a/pkg/filesystem/s3/s3_fileinfo.go
+++ b/pkg/filesystem/s3/s3_fileinfo.go
@@ -1,0 +1,60 @@
+package s3
+
+import (
+	"os"
+	"time"
+)
+
+// FileInfo implements os.FileInfo for a file in S3.
+type FileInfo struct {
+	name        string
+	directory   bool
+	sizeInBytes int64
+	modTime     time.Time
+}
+
+func NewFileInfo(name string, directory bool, sizeInBytes int64, _ time.Time) FileInfo {
+	return FileInfo{
+		name:        name,
+		directory:   directory,
+		sizeInBytes: sizeInBytes,
+	}
+}
+
+var _ os.FileInfo = (*FileInfo)(nil)
+
+// Name provides the base name of the file.
+func (fi FileInfo) Name() string {
+	return fi.name
+}
+
+// Size provides the length in bytes for a file.
+func (fi FileInfo) Size() int64 {
+	return fi.sizeInBytes
+}
+
+// Mode provides the file mode bits. For a file in S3 this defaults to
+// 664 for files, 775 for directories.
+// In the future this may return differently depending on the permissions
+// available on the bucket.
+func (fi FileInfo) Mode() os.FileMode {
+	if fi.directory {
+		return 0755
+	}
+	return 0664
+}
+
+// ModTime provides the last modification time.
+func (fi FileInfo) ModTime() time.Time {
+	return fi.modTime
+}
+
+// IsDir provides the abbreviation for Mode().IsDir()
+func (fi FileInfo) IsDir() bool {
+	return fi.directory
+}
+
+// Sys provides the underlying data source (can return nil)
+func (fi FileInfo) Sys() interface{} {
+	return nil
+}

--- a/pkg/filesystem/s3/s3_fs.go
+++ b/pkg/filesystem/s3/s3_fs.go
@@ -1,0 +1,235 @@
+package s3
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3iface"
+	"github.com/spf13/afero"
+)
+
+// Fs is an FS object backed by S3.
+type Fs struct {
+	bucket string
+	s3API  s3iface.S3API
+}
+
+var _ afero.Fs = (*Fs)(nil)
+
+// NewFs creates a new Fs object writing files to a given S3 bucket.
+func NewFs(bucket string, s3API s3iface.S3API) *Fs {
+	return &Fs{bucket: bucket, s3API: s3API}
+}
+
+// Name returns the type of FS object this is: Fs.
+func (Fs) Name() string { return "Fs" }
+
+// Create a file.
+func (fs Fs) Create(name string) (afero.File, error) {
+	file, err := fs.Open(name)
+	if err != nil {
+		return file, err
+	}
+	// Create(), like all of S3, is eventually consistent.
+	// To protect against unexpected behavior, have this method
+	// wait until S3 reports the object exists.
+	if s3Client, ok := fs.s3API.(*s3.S3); ok {
+		return file, s3Client.WaitUntilObjectExists(&s3.HeadObjectInput{
+			Bucket: aws.String(fs.bucket),
+			Key:    aws.String(name),
+		})
+	}
+	return file, err
+}
+
+// Mkdir makes a directory in S3.
+func (fs Fs) Mkdir(name string, perm os.FileMode) error {
+	_, err := fs.OpenFile(fmt.Sprintf("%s/", filepath.Clean(name)), os.O_CREATE, perm)
+	return err
+}
+
+// MkdirAll creates a directory and all parent directories if necessary.
+func (fs Fs) MkdirAll(path string, perm os.FileMode) error {
+	return fs.Mkdir(path, perm)
+}
+
+// Open a file for reading.
+// If the file doesn't exist, Open will create the file.
+func (fs Fs) Open(name string) (afero.File, error) {
+	if _, err := fs.Stat(name); err != nil {
+		if os.IsNotExist(err) {
+			return fs.OpenFile(name, os.O_CREATE, 0777)
+		}
+		return (*File)(nil), err
+	}
+	return NewFile(fs.bucket, name, fs.s3API, fs), nil
+}
+
+// OpenFile opens a file.
+func (fs Fs) OpenFile(name string, flag int, _ os.FileMode) (afero.File, error) {
+	file := NewFile(fs.bucket, name, fs.s3API, fs)
+	if flag&os.O_APPEND != 0 {
+		return file, errors.New("s3 is eventually consistent. Appending files will lead to trouble")
+	}
+	if flag&os.O_CREATE != 0 {
+		if _, err := file.WriteString(""); err != nil {
+			return file, err
+		}
+	}
+	return file, nil
+}
+
+// Remove a file.
+func (fs Fs) Remove(name string) error {
+	if _, err := fs.Stat(name); err != nil {
+		return err
+	}
+	_, err := fs.s3API.DeleteObject(&s3.DeleteObjectInput{
+		Bucket: aws.String(fs.bucket),
+		Key:    aws.String(name),
+	})
+	return err
+}
+
+// ForceRemove doesn't error if a file does not exist.
+func (fs Fs) ForceRemove(name string) error {
+	_, err := fs.s3API.DeleteObject(&s3.DeleteObjectInput{
+		Bucket: aws.String(fs.bucket),
+		Key:    aws.String(name),
+	})
+	return err
+}
+
+// RemoveAll removes a path.
+func (fs Fs) RemoveAll(path string) error {
+	s3dir := NewFile(fs.bucket, path, fs.s3API, fs)
+	fis, err := s3dir.Readdir(0)
+	if err != nil {
+		return err
+	}
+	for _, fi := range fis {
+		fullpath := filepath.Join(s3dir.Name(), fi.Name())
+		if fi.IsDir() {
+			if err := fs.RemoveAll(fullpath); err != nil {
+				return err
+			}
+		} else {
+			if err := fs.ForceRemove(fullpath); err != nil {
+				return err
+			}
+		}
+	}
+	// finally remove the "file" representing the directory
+	if err := fs.ForceRemove(s3dir.Name() + "/"); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Rename a file.
+// There is no method to directly rename an S3 object, so the Rename
+// will copy the file to an object with the new name and then delete
+// the original.
+func (fs Fs) Rename(oldname, newname string) error {
+	if oldname == newname {
+		return nil
+	}
+	_, err := fs.s3API.CopyObject(&s3.CopyObjectInput{
+		Bucket:               aws.String(fs.bucket),
+		CopySource:           aws.String(fs.bucket + oldname),
+		Key:                  aws.String(newname),
+		ServerSideEncryption: aws.String("AES256"),
+	})
+	if err != nil {
+		return err
+	}
+	_, err = fs.s3API.DeleteObject(&s3.DeleteObjectInput{
+		Bucket: aws.String(fs.bucket),
+		Key:    aws.String(oldname),
+	})
+	return err
+}
+
+func hasTrailingSlash(s string) bool {
+	return len(s) > 0 && s[len(s)-1] == '/'
+}
+
+func trimLeadingSlash(s string) string {
+	if len(s) > 0 && s[0] == '/' {
+		return s[1:]
+	}
+	return s
+}
+
+// Stat returns a FileInfo describing the named file.
+// If there is an error, it will be of type *os.PathError.
+func (fs Fs) Stat(name string) (os.FileInfo, error) {
+	nameClean := filepath.Clean(name)
+	out, err := fs.s3API.HeadObject(&s3.HeadObjectInput{
+		Bucket: aws.String(fs.bucket),
+		Key:    aws.String(nameClean),
+	})
+	if err != nil {
+		if strings.Contains(err.Error(), "404") {
+			statDir, err := fs.statDirectory(name)
+			return statDir, err
+		}
+		return FileInfo{}, &os.PathError{
+			Op:   "stat",
+			Path: name,
+			Err:  err,
+		}
+	} else if hasTrailingSlash(name) {
+		// user asked for a directory, but this is a file
+		return FileInfo{}, &os.PathError{
+			Op:   "stat",
+			Path: name,
+			//Err:  errors.New("not a directory"),
+			Err: os.ErrNotExist,
+		}
+	}
+	return NewFileInfo(filepath.Base(name), false, *out.ContentLength, *out.LastModified), nil
+}
+
+func (fs Fs) statDirectory(name string) (os.FileInfo, error) {
+	nameClean := filepath.Clean(name)
+	out, err := fs.s3API.ListObjectsV2(&s3.ListObjectsV2Input{
+		Bucket:  aws.String(fs.bucket),
+		Prefix:  aws.String(trimLeadingSlash(nameClean)),
+		MaxKeys: aws.Int64(1),
+	})
+	if err != nil {
+		return FileInfo{}, &os.PathError{
+			Op:   "stat",
+			Path: name,
+			Err:  err,
+		}
+	}
+	if *out.KeyCount == 0 && name != "" {
+		return FileInfo{}, &os.PathError{
+			Op:   "stat",
+			Path: name,
+			//Err:  errors.New("no such file or directory"),
+			Err: os.ErrNotExist,
+		}
+	}
+	return NewFileInfo(filepath.Base(name), true, 0, time.Time{}), nil
+}
+
+// Chmod is TODO
+func (Fs) Chmod(name string, mode os.FileMode) error {
+	panic("implement Chmod")
+	return nil
+}
+
+// Chtimes is TODO
+func (Fs) Chtimes(name string, atime time.Time, mtime time.Time) error {
+	panic("implement Chtimes")
+	return nil
+}

--- a/pkg/filesystem/s3/s3_fs.go
+++ b/pkg/filesystem/s3/s3_fs.go
@@ -23,7 +23,7 @@ type Fs struct {
 var _ afero.Fs = (*Fs)(nil)
 
 // NewFs creates a new Fs object writing files to a given S3 bucket.
-func NewFs(bucket string, s3API s3iface.S3API) *Fs {
+func NewFs(bucket string, s3API s3iface.S3API) afero.Fs {
 	return &Fs{bucket: bucket, s3API: s3API}
 }
 

--- a/pkg/filesystem/s3/s3_fs.go
+++ b/pkg/filesystem/s3/s3_fs.go
@@ -224,12 +224,10 @@ func (fs Fs) statDirectory(name string) (os.FileInfo, error) {
 
 // Chmod is TODO
 func (Fs) Chmod(name string, mode os.FileMode) error {
-	panic("implement Chmod")
-	return nil
+	return NotImplementedError{Error{Message: "implement Chmod"}}
 }
 
 // Chtimes is TODO
 func (Fs) Chtimes(name string, atime time.Time, mtime time.Time) error {
-	panic("implement Chtimes")
-	return nil
+	return NotImplementedError{Error{Message: "implement Chtimes"}}
 }

--- a/pkg/filesystem/s3_deprecated.go
+++ b/pkg/filesystem/s3_deprecated.go
@@ -10,10 +10,14 @@ import (
 	"github.com/spf13/viper"
 )
 
+// DEPRECATED
+// Please use Env.FS instead to work with S3 filesystem
 var s3sess = session.Must(session.NewSession(&aws.Config{
 	Region: aws.String(viper.GetString("AWS_REGION")),
 }))
 
+// DEPRECATED
+// Please use Env.FS instead to work with S3 filesystem
 func DeleteS3File(bucket string, filename string) error {
 	svc := s3.New(s3sess)
 	input := &s3.DeleteObjectInput{
@@ -28,6 +32,8 @@ func DeleteS3File(bucket string, filename string) error {
 	return nil
 }
 
+// DEPRECATED
+// Please use Env.FS instead to work with S3 filesystem
 func DownloadS3File(bucket string, filename string) ([]byte, error) {
 	downloader := s3manager.NewDownloader(s3sess)
 	buff := &aws.WriteAtBuffer{}
@@ -43,6 +49,8 @@ func DownloadS3File(bucket string, filename string) ([]byte, error) {
 	return buff.Bytes(), nil
 }
 
+// DEPRECATED
+// Please use Env.FS instead to work with S3 filesystem
 func UploadS3File(bucket string, filename string, content string) error {
 	uploader := s3manager.NewUploader(s3sess)
 	_, err := uploader.Upload(&s3manager.UploadInput{


### PR DESCRIPTION
- Deprecate old filesystem methods to work with s3
- Add FS to Env singleton
- Implement s3 filesystem for afero.Fs interface (copy-pasted from `https://github.com/spf13/afero/pull/90`)