### PR TITLE
404 gin http code to info log

### DIFF
--- a/pkg/web/middleware/logger.go
+++ b/pkg/web/middleware/logger.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"net/http"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -41,7 +42,7 @@ func Logger(c *gin.Context) {
 			"error": errors,
 		}).Error(path)
 	} else {
-		if statusCode < 400 {
+		if statusCode < http.StatusBadRequest || statusCode == http.StatusNotFound {
 			logger.Info(path)
 		} else {
 			logger.Error(path)

--- a/pkg/web/middleware/logger.go
+++ b/pkg/web/middleware/logger.go
@@ -42,6 +42,7 @@ func Logger(c *gin.Context) {
 			"error": errors,
 		}).Error(path)
 	} else {
+		// all codes below 400 and 404 not critical errors so we log them with error level "info"
 		if statusCode < http.StatusBadRequest || statusCode == http.StatusNotFound {
 			logger.Info(path)
 		} else {


### PR DESCRIPTION
На проді в сервіси наші постійно щимиться цілий підрільний клуб сканерів і це нераелаьно засирає логи, бо логер все, що не 400 логає з рівнем еррор. Це ніби не атка вже й важлива трабла, щоб писати це в логи(взагалі не требла) тому зробив так, щоб 404 логалось з рівнем інфо