### PR TITLE
fix mq connection: fail to connect with unescaped user data

### DIFF
--- a/pkg/lib/auth/service.go
+++ b/pkg/lib/auth/service.go
@@ -46,6 +46,10 @@ func (s *Service) AuthByBearerToken(token string) bool {
 		log.Error(err)
 		return false
 	}
+	if usrSes == nil {
+		log.Debugf("Seesion not found")
+		return false
+	}
 	if usrSes.ExpiresAt <= now {
 		log.Debugf("Seesion token is expired")
 		return false

--- a/pkg/mq/client.go
+++ b/pkg/mq/client.go
@@ -2,6 +2,7 @@ package mq
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"strconv"
 
@@ -35,7 +36,7 @@ func NewConnection() (*rabbitmq.Connection, error) {
 
 	amqpURI := fmt.Sprintf("amqp://%s:%s@%s:%s//%s?connection_timeout=%s",
 		user,
-		pass,
+		url.PathEscape(pass),
 		host,
 		port,
 		vhost,

--- a/pkg/mq/client.go
+++ b/pkg/mq/client.go
@@ -2,7 +2,6 @@ package mq
 
 import (
 	"fmt"
-	"net/url"
 	"os"
 	"strconv"
 
@@ -36,7 +35,7 @@ func NewConnection() (*rabbitmq.Connection, error) {
 
 	amqpURI := fmt.Sprintf("amqp://%s:%s@%s:%s//%s?connection_timeout=%s",
 		user,
-		url.PathEscape(pass),
+		pass,
 		host,
 		port,
 		vhost,

--- a/pkg/mq/config.go
+++ b/pkg/mq/config.go
@@ -45,6 +45,10 @@ func (c Config) Dsn() string {
 		}
 		params = strings.Join(pairs, "&")
 	}
+	// avoid double-escape
+	c.Username, _ = url.PathUnescape(c.Username)
+	c.Password, _ = url.PathUnescape(c.Password)
+	// compose
 	dsn := fmt.Sprintf("%s://%s:%s@%s:%s/%s?%s",
 		c.Driver,
 		c.UsernameEscaped(),

--- a/pkg/mq/config.go
+++ b/pkg/mq/config.go
@@ -1,29 +1,41 @@
 package mq
 
-import "net/url"
+import (
+	"errors"
+	"net/url"
+)
 
 type Config struct {
 	data *url.URL
 }
 
-func NewConfig(dsn string) Config {
-	conf := Config{}
-	conf.parse(dsn)
-	return conf
+func NewConfig(dsn string) (*Config, error) {
+	conf, err := parseDsn(dsn)
+	if err != nil {
+		return nil, err
+	}
+	return conf, nil
 }
 
 func (c Config) Dsn() string {
+	if c.data == nil {
+		return ""
+	}
 	return c.Data().String()
 }
 
 func (c Config) Data() *url.URL {
 	return c.data
 }
-func (c Config) parse(dsn string) Config {
+func parseDsn(dsn string) (*Config, error) {
+	if dsn == "" {
+		return nil, errors.New("dsn string is empty")
+	}
+	var conf Config
 	data, err := url.Parse(dsn)
 	if err != nil {
-		data = nil
+		return nil, err
 	}
-	c.data = data
-	return c
+	conf.data = data
+	return &conf, nil
 }

--- a/pkg/mq/config.go
+++ b/pkg/mq/config.go
@@ -2,31 +2,78 @@ package mq
 
 import (
 	"errors"
+	"fmt"
 	"net/url"
+	"strings"
+)
+
+const (
+	defaultDriver          = "amqp"
+	defaultHost            = "localhost"
+	defaultPort            = "5672"
+	paramConnectionTimeout = "connection_timeout"
 )
 
 type Config struct {
-	data *url.URL
+	Driver   string
+	Username string
+	Password string
+	Host     string
+	Port     string
+	Vhost    string
+	Params   map[string]string
 }
 
-func NewConfig(dsn string) (*Config, error) {
+func NewConfig() Config {
+	return loadDefaultConfig()
+}
+
+func NewConfigFromDsn(dsn string) (Config, error) {
 	conf, err := parseDsn(dsn)
 	if err != nil {
-		return nil, err
+		return Config{}, err
 	}
-	return conf, nil
+	return *conf, nil
 }
 
 func (c Config) Dsn() string {
-	if c.data == nil {
-		return ""
+	params := ""
+	if len(c.Params) != 0 {
+		var pairs []string
+		for k, v := range c.Params {
+			pairs = append(pairs, fmt.Sprintf("%s=%s", k, v))
+		}
+		params = strings.Join(pairs, "&")
 	}
-	return c.Data().String()
+	dsn := fmt.Sprintf("%s://%s:%s@%s:%s/%s?%s",
+		c.Driver,
+		c.UsernameEscaped(),
+		c.PasswordEscaped(),
+		c.Host,
+		c.Port,
+		c.Vhost,
+		params,
+	)
+	return dsn
 }
 
-func (c Config) Data() *url.URL {
-	return c.data
+func (c Config) UsernameEscaped() string {
+	return url.PathEscape(c.Username)
 }
+func (c Config) PasswordEscaped() string {
+	return url.PathEscape(c.Password)
+}
+func (c Config) VhostEscaped() string {
+	return url.PathEscape(c.Vhost)
+}
+func (c Config) Param(name string) string {
+	val, ok := c.Params[name]
+	if !ok {
+		return ""
+	}
+	return val
+}
+
 func parseDsn(dsn string) (*Config, error) {
 	if dsn == "" {
 		return nil, errors.New("dsn string is empty")
@@ -36,6 +83,36 @@ func parseDsn(dsn string) (*Config, error) {
 	if err != nil {
 		return nil, err
 	}
-	conf.data = data
+	// unescape auth data
+	usr, err := url.PathUnescape(data.User.Username())
+	if err != nil {
+		usr = data.User.Username()
+	}
+	p, _ := data.User.Password()
+	pass, err := url.PathUnescape(p)
+	if err != nil {
+		pass = p
+	}
+	// set data
+	conf.Driver = data.Scheme
+	conf.Username = usr
+	conf.Password = pass
+	conf.Host = data.Hostname()
+	conf.Port = data.Port()
+	conf.Vhost = strings.ReplaceAll(data.Path, "//", "/")
+	params := make(map[string]string, len(data.Query()))
+	for k, v := range data.Query() {
+		params[k], _ = url.PathUnescape(v[0])
+	}
+	conf.Params = params
 	return &conf, nil
+}
+
+func loadDefaultConfig() Config {
+	var conf Config
+	conf.Driver = defaultDriver
+	conf.Host = defaultHost
+	conf.Port = defaultPort
+	conf.Params = make(map[string]string)
+	return conf
 }

--- a/pkg/mq/config_test.go
+++ b/pkg/mq/config_test.go
@@ -1,0 +1,71 @@
+package mq
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewConfigSuccess(t *testing.T) {
+	dsn := "amqp://user:pass@host.com:1234/vhost?param=12"
+	conf, err := NewConfig(dsn)
+	// struct check
+	assert.Nil(t, err)
+	assert.NotNil(t, conf)
+	assert.IsType(t, &Config{}, conf)
+	assert.NotNil(t, conf.Data())
+	// data check
+	assert.IsType(t, &url.URL{}, conf.Data())
+	assert.Equal(t, "amqp", conf.Data().Scheme)
+	assert.Equal(t, "user", conf.Data().User.Username())
+	pass, set := conf.Data().User.Password()
+	assert.True(t, set)
+	assert.Equal(t, "pass", pass)
+	assert.Equal(t, "host.com", conf.Data().Hostname())
+	assert.Equal(t, "1234", conf.Data().Port())
+	assert.Equal(t, "/vhost", conf.Data().Path)
+	assert.Equal(t, "12", conf.Data().Query().Get("param"))
+	// dsn check
+	assert.Equal(t, dsn, conf.Data().String())
+	q := conf.Data().Query()
+	q.Set("timeout", "3")
+	conf.Data().RawQuery = q.Encode()
+	assert.Equal(t, "3", conf.Data().Query().Get("timeout"))
+	assert.Equal(t, conf.Dsn(), "amqp://user:pass@host.com:1234/vhost?param=12&timeout=3")
+}
+
+func TestNewConfigFail(t *testing.T) {
+	// scenario: empty dsn
+	conf, err := NewConfig("")
+	assert.NotNil(t, err)
+	assert.Nil(t, conf)
+
+	// scenario: bad dsn
+	conf, err = NewConfig("amqp://user:@host:1234//vhost")
+	assert.Nil(t, err)
+	assert.NotNil(t, conf)
+	assert.IsType(t, &Config{}, conf)
+	assert.NotNil(t, conf.Data())
+	assert.IsType(t, &url.URL{}, conf.Data())
+	assert.Equal(t, "amqp", conf.Data().Scheme)
+	assert.Equal(t, "user:", conf.Data().User.String())
+	assert.Equal(t, "user", conf.Data().User.Username())
+	pass, set := conf.Data().User.Password()
+	assert.True(t, set)
+	assert.Equal(t, "", pass)
+	assert.Equal(t, "host", conf.Data().Hostname())
+	assert.Equal(t, "1234", conf.Data().Port())
+	assert.NotEqual(t, "/vhost", conf.Data().Path)
+	assert.Equal(t, "", conf.Data().Query().Get("param"))
+
+	// scenario: valid, but unescaped dsn
+	dsn := "amqp://user:fdjkh%23${#!fdf0-0&@rabbitmq.host:5672//my-vhost?connection_timeout=500"
+	conf, err = NewConfig(dsn)
+	assert.NotNil(t, err)
+	assert.Nil(t, conf)
+	escapedDSN := url.PathEscape(dsn)
+	conf, err = NewConfig(escapedDSN)
+	assert.Nil(t, err)
+	assert.NotNil(t, conf)
+}

--- a/pkg/mq/config_test.go
+++ b/pkg/mq/config_test.go
@@ -37,9 +37,11 @@ func TestNewConfigFromDsnSuccess(t *testing.T) {
 	conf.Params["timeout"] = "3"
 	assert.Equal(t, "3", conf.Param("timeout"))
 	// params order is unpredicted, so...
-	res1 := conf.Dsn() == "amqp://user:pass@host.com:1234//vhost?param=12&timeout=3"
-	res2 := conf.Dsn() == "amqp://user:pass@host.com:1234//vhost?timeout=3&param=12"
-	assert.True(t, res1 || res2)
+	vars := []string{
+		"amqp://user:pass@host.com:1234//vhost?param=12&timeout=3",
+		"amqp://user:pass@host.com:1234//vhost?timeout=3&param=12",
+	}
+	assert.Contains(t, vars, conf.Dsn())
 }
 
 func TestNewConfigFromDsnFail(t *testing.T) {

--- a/pkg/mq/config_test.go
+++ b/pkg/mq/config_test.go
@@ -1,71 +1,69 @@
 package mq
 
 import (
-	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestNewConfigSuccess(t *testing.T) {
-	dsn := "amqp://user:pass@host.com:1234/vhost?param=12"
-	conf, err := NewConfig(dsn)
+func TestNewConfig(t *testing.T) {
+	conf := NewConfig()
+	assert.NotNil(t, conf)
+	assert.Equal(t, defaultDriver, conf.Driver)
+	assert.Equal(t, defaultHost, conf.Host)
+	assert.Equal(t, defaultPort, conf.Port)
+}
+
+func TestNewConfigFromDsnSuccess(t *testing.T) {
+	dsn := "amqp://user:pass@host.com:1234//vhost?param=12"
+	conf, err := NewConfigFromDsn(dsn)
 	// struct check
 	assert.Nil(t, err)
 	assert.NotNil(t, conf)
-	assert.IsType(t, &Config{}, conf)
-	assert.NotNil(t, conf.Data())
+	assert.IsType(t, Config{}, conf)
 	// data check
-	assert.IsType(t, &url.URL{}, conf.Data())
-	assert.Equal(t, "amqp", conf.Data().Scheme)
-	assert.Equal(t, "user", conf.Data().User.Username())
-	pass, set := conf.Data().User.Password()
-	assert.True(t, set)
-	assert.Equal(t, "pass", pass)
-	assert.Equal(t, "host.com", conf.Data().Hostname())
-	assert.Equal(t, "1234", conf.Data().Port())
-	assert.Equal(t, "/vhost", conf.Data().Path)
-	assert.Equal(t, "12", conf.Data().Query().Get("param"))
+	assert.Equal(t, "amqp", conf.Driver)
+	assert.Equal(t, "user", conf.Username)
+	assert.Equal(t, "user", conf.UsernameEscaped())
+	assert.Equal(t, "pass", conf.Password)
+	assert.Equal(t, "pass", conf.PasswordEscaped())
+	assert.Equal(t, "host.com", conf.Host)
+	assert.Equal(t, "1234", conf.Port)
+	assert.Equal(t, "/vhost", conf.Vhost)
+	assert.Equal(t, "%2Fvhost", conf.VhostEscaped())
+	assert.Equal(t, "12", conf.Param("param"))
 	// dsn check
-	assert.Equal(t, dsn, conf.Data().String())
-	q := conf.Data().Query()
-	q.Set("timeout", "3")
-	conf.Data().RawQuery = q.Encode()
-	assert.Equal(t, "3", conf.Data().Query().Get("timeout"))
-	assert.Equal(t, conf.Dsn(), "amqp://user:pass@host.com:1234/vhost?param=12&timeout=3")
+	assert.Equal(t, dsn, conf.Dsn())
+	conf.Params["timeout"] = "3"
+	assert.Equal(t, "3", conf.Param("timeout"))
+	// params order is unpredicted, so...
+	res1 := conf.Dsn() == "amqp://user:pass@host.com:1234//vhost?param=12&timeout=3"
+	res2 := conf.Dsn() == "amqp://user:pass@host.com:1234//vhost?timeout=3&param=12"
+	assert.True(t, res1 || res2)
 }
 
-func TestNewConfigFail(t *testing.T) {
+func TestNewConfigFromDsnFail(t *testing.T) {
 	// scenario: empty dsn
-	conf, err := NewConfig("")
+	conf, err := NewConfigFromDsn("")
 	assert.NotNil(t, err)
-	assert.Nil(t, conf)
-
 	// scenario: bad dsn
-	conf, err = NewConfig("amqp://user:@host:1234//vhost")
+	conf, err = NewConfigFromDsn("amqp://user:@host:1234//vhost")
 	assert.Nil(t, err)
 	assert.NotNil(t, conf)
-	assert.IsType(t, &Config{}, conf)
-	assert.NotNil(t, conf.Data())
-	assert.IsType(t, &url.URL{}, conf.Data())
-	assert.Equal(t, "amqp", conf.Data().Scheme)
-	assert.Equal(t, "user:", conf.Data().User.String())
-	assert.Equal(t, "user", conf.Data().User.Username())
-	pass, set := conf.Data().User.Password()
-	assert.True(t, set)
-	assert.Equal(t, "", pass)
-	assert.Equal(t, "host", conf.Data().Hostname())
-	assert.Equal(t, "1234", conf.Data().Port())
-	assert.NotEqual(t, "/vhost", conf.Data().Path)
-	assert.Equal(t, "", conf.Data().Query().Get("param"))
+	assert.IsType(t, Config{}, conf)
+	assert.Equal(t, "user", conf.Username)
+	assert.Equal(t, "", conf.Password)
+	assert.Equal(t, "host", conf.Host)
+	assert.Equal(t, "1234", conf.Port)
+	assert.NotEqual(t, "vhost", conf.Vhost)
+	assert.NotEqual(t, "vhost", conf.VhostEscaped())
+	assert.Equal(t, "", conf.Param("param"))
 
-	// scenario: valid, but unescaped dsn
-	dsn := "amqp://user:fdjkh%23${#!fdf0-0&@rabbitmq.host:5672//my-vhost?connection_timeout=500"
-	conf, err = NewConfig(dsn)
+	// scenario: unescaped auth data
+	dsn := "amqp://us$^er:fdjkh%23${#!fdf0-0&@rabbitmq.host:5672//my-vhost?connection_timeout=500"
+	conf, err = NewConfigFromDsn(dsn)
 	assert.NotNil(t, err)
-	assert.Nil(t, conf)
-	escapedDSN := url.PathEscape(dsn)
-	conf, err = NewConfig(escapedDSN)
+	dsnOK := "amqp://us%24%5Eer:fdjkh%2523%24%7B%23%21fdf0-0%26@rabbitmq.host:5672//my-vhost?connection_timeout=500"
+	conf, err = NewConfigFromDsn(dsnOK)
 	assert.Nil(t, err)
-	assert.NotNil(t, conf)
 }

--- a/pkg/mq/connection.go
+++ b/pkg/mq/connection.go
@@ -6,14 +6,9 @@ import (
 	"github.com/isayme/go-amqp-reconnect/rabbitmq"
 )
 
-const (
-	timeout = "connection_timeout"
-)
-
-func NewConnectionWithConfig(conf *Config) (*rabbitmq.Connection, error) {
-	t := conf.Data().Query().Get(timeout)
-	if t == "" {
-		conf.Data().Query().Set(timeout, strconv.Itoa(defaultConnectTimeout))
+func NewConnectionWithConfig(conf Config) (*rabbitmq.Connection, error) {
+	if conf.Param(paramConnectionTimeout) == "" {
+		conf.Params[paramConnectionTimeout] = strconv.Itoa(defaultConnectTimeout)
 	}
 	conn, err := rabbitmq.Dial(conf.Dsn())
 	if err != nil {

--- a/pkg/mq/connection.go
+++ b/pkg/mq/connection.go
@@ -10,7 +10,7 @@ const (
 	timeout = "connection_timeout"
 )
 
-func NewConnectionWithConfig(conf Config) (*rabbitmq.Connection, error) {
+func NewConnectionWithConfig(conf *Config) (*rabbitmq.Connection, error) {
 	t := conf.Data().Query().Get(timeout)
 	if t == "" {
 		conf.Data().Query().Set(timeout, strconv.Itoa(defaultConnectTimeout))


### PR DESCRIPTION
столкнулся с такой проблемой - если `user / password` содержат спец-символы (`%!{}$`) - мы ловим панику...
```
panic: failed to connect to mq: parse "amqp://******:*****@rabbitmq-eks....
```